### PR TITLE
Gestiona imagenes de las medallas con clase BadgeImage

### DIFF
--- a/slack_badges_bot/adapters/repositories.py
+++ b/slack_badges_bot/adapters/repositories.py
@@ -11,7 +11,7 @@ from typing import Type
 from io import BytesIO
 
 from slack_badges_bot.services.repositories import EntityRepository
-from slack_badges_bot.entities.entities import Badge, BadgeImage, BadgeImage
+from slack_badges_bot.entities.entities import Badge, BadgeImage
 
 __author__ = 'jesús torres'
 __contact__ = "jmtorres@ull.es"

--- a/slack_badges_bot/adapters/repositories.py
+++ b/slack_badges_bot/adapters/repositories.py
@@ -11,12 +11,12 @@ from typing import Type
 from io import BytesIO
 
 from slack_badges_bot.services.repositories import EntityRepository
-from slack_badges_bot.entities.entities import Badge
+from slack_badges_bot.entities.entities import Badge, BadgeImage, BadgeImage
 
-__author__ = 'Jesús Torres'
+__author__ = 'jesús torres'
 __contact__ = "jmtorres@ull.es"
-__license__ = "Apache License, Version 2.0"
-__copyright__ = "Copyright 2019 {0} <{1}>".format(__author__, __contact__)
+__license__ = "apache license, version 2.0"
+__copyright__ = "copyright 2019 {0} <{1}>".format(__author__, __contact__)
 
 def json_dump_default(o):
     """Función para pasar por el argumento default a la función json.dump().
@@ -59,17 +59,19 @@ class EntityJsonRepository(EntityRepository):
 
     def save(self, entity, overwrite=False):
         if isinstance(entity, Badge):
-            if isinstance(entity.image, BytesIO):
-                logging.debug(f'EntityJSONRepository.save: {entity.image}')
-                image_filepath = self._build_filepath(entity.id.hex, entity.image_type)
-                with image_filepath.open('wb') as f:
-                    entity.image.seek(0)
-                    f.write(entity.image.read())
-                entity.image = 'file://' + str(image_filepath)
+            if isinstance(entity.image, BadgeImage):
+                self.save_badgeimage(entity)
         filepath = self._build_filepath(entity.id.hex, 'json')
         mode = "w" if overwrite else "x"
         with filepath.open(mode) as f:
             json.dump(dataclasses.asdict(entity), f, default=json_dump_default)
+
+    def save_badgeimage(self, entity):
+        image_filepath = self._build_filepath(entity.id.hex, entity.image.suffix)
+        if entity.image.path is None:
+            with image_filepath.open('wb') as f:
+                f.write(entity.image.get_data().read())
+        entity.image = image_filepath
 
     def load(self, id):
         logging.debug(f'EntityJSONRepository.load({id})')

--- a/slack_badges_bot/entities/__init__.py
+++ b/slack_badges_bot/entities/__init__.py
@@ -1,1 +1,2 @@
 from .entities import *
+from .badgeimage import *

--- a/slack_badges_bot/entities/badgeimage.py
+++ b/slack_badges_bot/entities/badgeimage.py
@@ -1,0 +1,45 @@
+import logging
+
+from dataclasses import dataclass
+from pathlib import Path
+from io import BufferedIOBase
+from PIL import Image as PILImage
+
+__author__ = 'Martín Belda'
+__contact__ = "mbelda@gmail.com"
+__license__ = "apache license, version 2.0"
+__copyright__ = "copyright 2019 {0} <{1}>".format(__author__, __contact__)
+
+'''
+Clase que puede guardar una imagen de dos maneras
+1. Guardando la ruta de la imagen en Image.path
+2. Guardando los datos de la imagen en Image.data
+Para acceder a data se usa la función get_data
+'''
+@dataclass
+class BadgeImage:
+    path: Path
+    data: BufferedIOBase
+    suffix: str = None
+
+
+    def __post_init__(self):
+        if self.path:
+            assert isinstance(self.path, str), f'path of type {type(self.path)} not allowed'
+            self.path = Path(self.path)
+            self.suffix = self.path.suffix[1:] # quitar el "." de ".png"
+        if self.data:
+            assert isinstance(self.data, BufferedIOBase), f'data of type {type(self.data)} not allowed'
+            self.data = self.data
+            self.data.seek(0)
+            self.suffix = str(PILImage.open(self.data).format).lower()
+
+    def get_data(self):
+        ''' Método para acceder a self.data
+        Carga la imagen si no está en memoria
+        '''
+        if self.data is None:
+            assert self.path is not None
+            self.data = open(self.path, 'rb')
+        self.data.seek(0)
+        return self.data

--- a/slack_badges_bot/entities/entities.py
+++ b/slack_badges_bot/entities/entities.py
@@ -40,9 +40,6 @@ class Badge:
     description: str
     criteria: List[str]
     image: Union[BadgeImage, str]
-    #_image: Image = field(init=False, repr=False)
-    # problema: dataclasses.asdict() serializa también _image en el json
-    # consecuencia: en el load intenta inicializar un atributo _image con init=False
 
     def __post_init__(self):
         logging.debug(f'Badge creado: {self}')

--- a/slack_badges_bot/entities/entities.py
+++ b/slack_badges_bot/entities/entities.py
@@ -3,13 +3,14 @@
 import inspect
 import logging
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from pathlib import Path
 from typing import List, Union
-from io import BytesIO
+from io import BufferedIOBase
 
 from slack_badges_bot.entities.entityid import EntityID
+from slack_badges_bot.entities.badgeimage import BadgeImage
 
 __author__ = 'Jesús Torres'
 __contact__ = "jmtorres@ull.es"
@@ -24,15 +25,27 @@ class Person:
 
 @dataclass
 class Badge:
+    """Clase para representar medallas
+    Attributes:
+        id (EntityID): identificador único.
+        name (str): nombre de la medalla.
+        description (str): descripción de la medalla.
+        criteria (str): criterios para ganar la medalla.
+        image (BadgeImage, str): imagen de la medalla.
+            puede ser un string con la ruta del archivo o
+            una instancia de la clase BadgeImage.
+    """
     id: EntityID
     name: str
     description: str
     criteria: List[str]
-    image: Union[Path, str, BytesIO] # Llama al setter
-    image_type: str
+    image: Union[BadgeImage, str]
+    #_image: Image = field(init=False, repr=False)
+    # problema: dataclasses.asdict() serializa también _image en el json
+    # consecuencia: en el load intenta inicializar un atributo _image con init=False
 
     def __post_init__(self):
-        logging.debug(f'Created new Badge {self}')
+        logging.debug(f'Badge creado: {self}')
 
 @dataclass
 class Award:
@@ -40,3 +53,15 @@ class Award:
     timestamp: datetime
     person: Person
     badge: Badge
+
+
+def json_default(o):
+    if isinstance(o, BufferedReader):
+        o = None
+
+if __name__ == '__main__': # Probando
+    logging.basicConfig(level=logging.DEBUG)
+    b = Badge(id=EntityID.generate_unique_id(),\
+            name='Prueba', description='desc',\
+            criteria=[], image='/tmp/prueba.png')#open('/tmp/prueba.png', 'rb'))
+    print(b.asdict_factory())

--- a/slack_badges_bot/services/badge.py
+++ b/slack_badges_bot/services/badge.py
@@ -67,11 +67,6 @@ class BadgeService:
             return badge.image.get_data()
         raise TypeError(f'BadgeService.open_image: Can\'t open image of type {type(badge.image)}')
 
-    def image_type(self, image_bytes: BytesIO) -> str:
-        assert isinstance(image_bytes, BytesIO),\
-            'BadgeService.image_type: image is not an instance of BytesIO'
-        return str(Image.open(image_bytes).format).lower()
-
     def validate_image(self, image_bytes: BytesIO) -> bool:
         #https://openbadges.org/developers/#badge-images
         assert isinstance(image_bytes, BytesIO),\

--- a/slack_badges_bot/services/badge.py
+++ b/slack_badges_bot/services/badge.py
@@ -60,7 +60,7 @@ class BadgeService:
         '''
         if isinstance(badge.image, str):
             if Path(badge.image).exists:
-                badge.image = BadgeImage(path=badge.image)
+                badge.image = BadgeImage(path=badge.image, data=None)
             else:
                 raise ValueError(f'BadgeService.open_image: path {badge.image} doesn\'t exist')
         if isinstance(badge.image, BadgeImage):

--- a/slack_badges_bot/services/badge.py
+++ b/slack_badges_bot/services/badge.py
@@ -60,7 +60,7 @@ class BadgeService:
         '''
         if isinstance(badge.image, str):
             if Path(badge.image).exists:
-                badge.image = Image(path=badge.image)
+                badge.image = BadgeImage(path=badge.image)
             else:
                 raise ValueError(f'BadgeService.open_image: path {badge.image} doesn\'t exist')
         if isinstance(badge.image, BadgeImage):


### PR DESCRIPTION
He creado una clase BadgeImage en que guarda la ruta, los datos y el tipo (.png, .svg) de la imagen.
Tiene un método get_data() que carga la imagen si está en un archivo.

Cuando se guarda una medalla se sustituye el BadgeImage.image por un string que indica la ruta del archivo. Quité lo de file:///... porque una medalla siempre va a tener una ruta de archivo local:
```python
def save_badgeimage(self, entity):
        image_filepath = self._build_filepath(entity.id.hex, entity.image.suffix)
        if entity.image.path is None:
            with image_filepath.open('wb') as f:
                f.write(entity.image.get_data().read())
        entity.image = image_filepath
```
La función load queda igual que antes.

BadgeService.open_image sustituye el atributo image por un BadgeImage si detecta que es un string, y luego llama a BadgeImage.get_data que devuelve un BufferedBaseIO
```python
 def open_image(self, badge: Badge) -> BufferedIOBase:
        '''
        Método para acceder a la imagen de una medalla
        '''
        if isinstance(badge.image, str):
            if Path(badge.image).exists:
                badge.image = Image(path=badge.image)
            else:
                raise ValueError(f'BadgeService.open_image: path {badge.image} doesn\'t exist')
        if isinstance(badge.image, BadgeImage):
            return badge.image.get_data()
        raise TypeError(f'BadgeService.open_image: Can\'t open image of type {type(badge.image)}')
```
Intenté hacerlo con `@property`, haciendo un setter que al pasarle un string o un BytesIO creara la imagen, pero daba problemas por todos lados.
