### PR TITLE
Implementa la funcionalidad de listar las medallas en slack

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ verify_ssl = true
 aiohttp = "*"
 punq = "*"
 pillow = "*"
-aiohttp-validate = {editable = true,git = "/home/mbelda/repos/aiohttp_validate"}
+aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
 badge-cli = {editable = true,path = "./badge-cli"}
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,9 @@ verify_ssl = true
 aiohttp = "*"
 punq = "*"
 pillow = "*"
-aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
+#aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
 badge-cli = {editable = true,path = "./badge-cli"}
+aiohttp-validate = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,9 @@ verify_ssl = true
 aiohttp = "*"
 punq = "*"
 pillow = "*"
-aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
-badge-cli = {editable = true,path = "./badge-cli"}
+#aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
+badge-cli = {path = "./badge-cli",editable = true}
+aiohttp-validate = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f68f9f6ad5c20eaac1c78e306d2391e62dc843bee1db56d43e87c4bd1821dc9"
+            "sha256": "6eaf9fd7bbab72a682f12b53428fcbdade2236a408efad616e408d2159ac6557"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,7 +46,7 @@
         },
         "aiohttp-validate": {
             "editable": true,
-            "git": "file:///home/mbelda/repos/aiohttp_validate",
+            "git": "https://github.com/alu0100832211/aiohttp_validate",
             "ref": "894ac6a4d84b7bb9a480e34a78ea6d5a518f9fd3"
         },
         "async-timeout": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6eaf9fd7bbab72a682f12b53428fcbdade2236a408efad616e408d2159ac6557"
+            "sha256": "7a04e5567d8ed46195fbd40a8f31a1a0f7b7e6bde267a05b67c1bdb73e816e7e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,9 +45,11 @@
             "version": "==3.5.4"
         },
         "aiohttp-validate": {
-            "editable": true,
-            "git": "https://github.com/alu0100832211/aiohttp_validate",
-            "ref": "894ac6a4d84b7bb9a480e34a78ea6d5a518f9fd3"
+            "hashes": [
+                "sha256:4e643e35a3ef14e769f5e13480c78821de7450ae921bac1dae646814718242bc"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "async-timeout": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6eaf9fd7bbab72a682f12b53428fcbdade2236a408efad616e408d2159ac6557"
+            "sha256": "7a04e5567d8ed46195fbd40a8f31a1a0f7b7e6bde267a05b67c1bdb73e816e7e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,9 +45,11 @@
             "version": "==3.5.4"
         },
         "aiohttp-validate": {
-            "editable": true,
-            "git": "https://github.com/alu0100832211/aiohttp_validate",
-            "ref": "894ac6a4d84b7bb9a480e34a78ea6d5a518f9fd3"
+            "hashes": [
+                "sha256:4e643e35a3ef14e769f5e13480c78821de7450ae921bac1dae646814718242bc"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "async-timeout": {
             "hashes": [
@@ -177,7 +179,8 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
+                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533",
+                "sha256:bba6617d52f435501434650b7345efec607b65162c29d60646273f66d807ed50"
             ],
             "version": "==0.15.4"
         },

--- a/slack_badges_bot/adapters/api.py
+++ b/slack_badges_bot/adapters/api.py
@@ -132,5 +132,20 @@ class WebService:
                     return BytesIO(await resp.read())
         raise BadgeImageError(f'WebService.urltobytes: couldn\'t dowload badge image from {url}')
 
+    async def badge_image_handler(self, request):
+        try:
+            badge_id = request.match_info['badge_id']
+            badge = self.badge_service.retrieve(badge_id)
+            image_fd = self.badge_service.open_image(badge)
+            logging.debug(f'badge_image_handler: {image_bytes}')
+            response = web.Response(body=image_fd.read(), content_type='application/image')
+        except:
+            traceback.print_exc(file=sys.stdout)
+            response = web.HTTPBadRequest()
+        return response
+
+
+
     def _setup_routes(self):
         self.app.router.add_post('/badges/create', self.create_badge_handler)
+        self.app.router.add_get('/badges/{badge_id}/image', self.badge_image_handler)

--- a/slack_badges_bot/adapters/api.py
+++ b/slack_badges_bot/adapters/api.py
@@ -137,7 +137,6 @@ class WebService:
             badge_id = request.match_info['badge_id']
             badge = self.badge_service.retrieve(badge_id)
             image_fd = self.badge_service.open_image(badge)
-            logging.debug(f'badge_image_handler: {image_bytes}')
             response = web.Response(body=image_fd.read(), content_type='application/image')
         except:
             traceback.print_exc(file=sys.stdout)

--- a/slack_badges_bot/adapters/blockbuilder.py
+++ b/slack_badges_bot/adapters/blockbuilder.py
@@ -1,0 +1,67 @@
+#encoding: utf-8
+from slack_badges_bot.services.config import ConfigService
+"""
+Esta clase está pensada
+para enviar mensajes de slack
+con un formato bonito.
+"""
+
+class BlockBuilder:
+    def __init__(self, config: ConfigService):
+        self.config = config
+
+
+    def award_text_block(self, user_id, badge_name, award_png_url):
+        return [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Nueva medalla para {user_id}*\n¡Felicidades {user_id}! has recibido {badge_name}"
+                        }
+                    },
+                {
+                    "type": "image",
+                    "title": {
+                        "type": "plain_text",
+                        "text": f"{badge_name}",
+                        "emoji": True
+                        },
+                    "image_url": f"{award_png_url}",
+                    "alt_text": f"{badge_name}"
+                    }
+                ]
+
+    def badges_block(self, badges):
+        block = []
+        for badge in badges:
+            image_url = self.config["BADGES_URL"] + f"/{badge.id_str}/image"
+            badge_block = self._badge_block(name=badge.name,
+                                           description=badge.description,
+                                           criteria=badge.criteria,
+                                           image_url=image_url)
+            for element in badge_block:
+                block.append(element)
+        return block
+
+    def _badge_block(self, name, description, criteria, image_url):
+        name = f":medal: {name} :medal:"
+        description = f"_{description}_"
+        criteria = "\n".join([":point_right:" + criterion for criterion in criteria])
+        return [
+                {
+                    "type": "divider"
+                    },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"{name}\n{description}\n{criteria}\n"
+                        },
+                    "accessory": {
+                        "type": "image",
+                        "image_url": f"{image_url}",
+                        "alt_text": f"{name}"
+                        }
+                    }
+                ]

--- a/slack_badges_bot/adapters/repositories.py
+++ b/slack_badges_bot/adapters/repositories.py
@@ -74,7 +74,6 @@ class EntityJsonRepository(EntityRepository):
         entity.image = image_filepath
 
     def load(self, id):
-        logging.debug(f'EntityJSONRepository.load({id})')
         filepath = self._build_filepath(id, 'json')
         with filepath.open("r") as f:
             json_loaded = json.load(f, object_hook=json_load_object_hook)
@@ -82,7 +81,6 @@ class EntityJsonRepository(EntityRepository):
 
     def get_all_ids(self):
         all_ids = [name.stem for name in self.path.glob(self.FILENAME_TEMPLATE.format(id='*', filetype='json'))]
-        logging.debug(f'all_ids = {all_ids}')
         return all_ids
 
     def check_if_exist(self, id):

--- a/slack_badges_bot/adapters/repositories.py
+++ b/slack_badges_bot/adapters/repositories.py
@@ -81,7 +81,9 @@ class EntityJsonRepository(EntityRepository):
             return self.stored_type(**json_loaded)
 
     def get_all_ids(self):
-        return [name.stem for name in self.path.glob(self.FILENAME_TEMPLATE.format(id='*', filetype='json'))]
+        all_ids = [name.stem for name in self.path.glob(self.FILENAME_TEMPLATE.format(id='*', filetype='json'))]
+        logging.debug(f'all_ids = {all_ids}')
+        return all_ids
 
     def check_if_exist(self, id):
         filepath = self._build_filepath(id)

--- a/slack_badges_bot/entities/entities.py
+++ b/slack_badges_bot/entities/entities.py
@@ -44,6 +44,10 @@ class Badge:
     def __post_init__(self):
         logging.debug(f'Badge creado: {self}')
 
+    @property
+    def id_str(self):
+        return str(self.id.hex)
+
 @dataclass
 class Award:
     id: EntityID

--- a/slack_badges_bot/entities/entities.py
+++ b/slack_badges_bot/entities/entities.py
@@ -41,9 +41,6 @@ class Badge:
     criteria: List[str]
     image: Union[BadgeImage, str]
 
-    def __post_init__(self):
-        logging.debug(f'Badge creado: {self}')
-
     @property
     def id_str(self):
         return str(self.id.hex)

--- a/slack_badges_bot/services/badge.py
+++ b/slack_badges_bot/services/badge.py
@@ -23,27 +23,22 @@ class BadgeService:
 
     def create(self, name: str, description: str,
                 criteria: List[str], image: BytesIO):
-        logging.debug(f'LLAMADA a BadgeService.create({name})')
         image = BadgeImage(path=None, data=image)
         badge = Badge(id=EntityID.generate_unique_id(), name=name, description=description, criteria=criteria,
                       image=image)
-        logging.debug(f'CREADO: {badge}')
         self.badge_repository.save(badge)
-        logging.debug(f'GUARDADO: {badge}')
 
     def retrieve(self, id):
         return self.badge_repository.load(id)
 
     def retrieve_ids(self):
         all_ids = self.badge_repository.get_all_ids()
-        logging.debug(all_ids)
         return all_ids
 
     def check_if_exist(self, id):
         return self.badge_repository.check_if_exist(id)
 
     def name_exists(self, badge_name):
-        logging.debug(f'Comprobando si existe nombre {badge_name}')
 
         ids = self.retrieve_ids()
         badge_name = badge_name.lower().replace(" ", "")
@@ -51,9 +46,7 @@ class BadgeService:
             badge = self.retrieve(id)
             retrieved_badge_name = badge.name.lower().replace(" ", "")
             if badge_name == retrieved_badge_name:
-                logging.debug(f'{badge_name} existe!')
                 return True
-        logging.debug(f'{badge_name} no existe')
         return False
 
     def open_image(self, badge: Badge) -> BufferedIOBase:

--- a/slack_badges_bot/services/badge.py
+++ b/slack_badges_bot/services/badge.py
@@ -35,7 +35,9 @@ class BadgeService:
         return self.badge_repository.load(id)
 
     def retrieve_ids(self):
-        return self.badge_repository.get_all_ids()
+        all_ids = self.badge_repository.get_all_ids()
+        logging.debug(all_ids)
+        return all_ids
 
     def check_if_exist(self, id):
         return self.badge_repository.check_if_exist(id)

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -1,6 +1,9 @@
 """Configuración por defecto de la aplicación.
 """
+import os
+
 from pathlib import Path
+
 
 __author__ = 'Jesús Torres'
 __contact__ = "jmtorres@ull.es"
@@ -17,6 +20,8 @@ class DefaultConfig:
     BADGE_NAME_MIN_LENGTH = 5
     BADGE_DESCRIPTION_MIN_LENGTH = 5
     BADGE_MIN_CRITERIA = 1
+    SLACK_SIGNING_SECRET = os.getenv('SLACK_SIGNING_SECRET')
+    SLACK_VERIFY_SECONDS = 5 * 60
 
     # Ver https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.run_app
     # Para los valores por defecto de estas opciones

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -10,6 +10,8 @@ __copyright__ = "Copyright 2019 {0} <{1}>".format(__author__, __contact__)
 
 class DefaultConfig:
     DEBUG = True
+    API_URL = 'http://vituin-chat.iaas.ull.es/api'
+    BADGES_URL = f'{API_URL}/badges'
     DATA_PATH = '../data'  # Relativo al directorio de trabajo de la aplicación
     BADGES_PATH = '../data/badges'
     BADGE_NAME_MIN_LENGTH = 5


### PR DESCRIPTION
- Comprueba la peticion usando los signed secrets
- Muestra el mensaje con formato de bloques en slack

Al principio tuve un problema con la peticion que llega desde slack al servidor en

```python
async def slash_command_handler(self, request):
        # TODO: Comprobar argumentos en request y añadir manejo de errores y excepciones
        # TODO: Usar signed secrets para comprobar que quien hace la petición es Slack.
        #       Ver https://api.slack.com/docs/verifying-requests-from-slack
        try:
            request.query['text']
```

request.query['text'] produce "KeyError: 'text'"
Así que escribí un método para pasarlo todo a json con urllib:

```python
    async def urlstring_to_json(self, request: web.Request):
        request_bytes = await request.read()
        request_json = urllib.parse.parse_qs(request_bytes.decode('utf-8'))
        request_json = {key:request_json[key][0] for key in request_json}
        return request_json
```

De resto, todo bien. Así se ve en slack:


![Peek 2019-08-09 02-02](https://user-images.githubusercontent.com/32129742/62746964-1c7fe200-ba4a-11e9-9db0-638373dd938c.gif)
