### PR TITLE
 Separar API linea de comandos y OpenBadges

### DIFF
--- a/slack_badges_bot/adapters/__init__.py
+++ b/slack_badges_bot/adapters/__init__.py
@@ -1,1 +1,1 @@
-from . import api, repositories, slack
+from . import api, repositories, slack, openbadgesapi

--- a/slack_badges_bot/adapters/api.py
+++ b/slack_badges_bot/adapters/api.py
@@ -187,9 +187,14 @@ class WebService:
             response = web.HTTPInternalServerError()
         return response
 
+    async def revocation_handler(self, request: web.Request):
+        issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
+        return web.json_response(issuer.revocationList)
+
     def _setup_routes(self):
         self.app.router.add_post('/badges/create', self.create_badge_handler)
         self.app.router.add_get('/badges/{badge_id}/{requested_data}', self.badge_handler)
         self.app.router.add_get('/issuer', self.issuer_handler)
         self.app.router.add_get('/awards/{award_id}/{requested_data}', self.award_handler)
+        self.app.router.add_get('/revocation', self.revocation_handler)
         #TODO: self.app.router.add_get('/{entity}/{id}/{requested_data}', self.entity_handler)

--- a/slack_badges_bot/adapters/api.py
+++ b/slack_badges_bot/adapters/api.py
@@ -1,17 +1,11 @@
-"""Servicio web de gestión de la aplicación.
+"""API para la línea de comandos
 """
 import json
-import logging
-import uuid
-import imghdr
 import base64
 import binascii
 import traceback
 import sys
-import os
 import re
-import inspect
-import mimetypes
 
 from aiohttp import web
 from aiohttp import ClientSession
@@ -21,10 +15,7 @@ from io import BytesIO
 
 from slack_badges_bot.entities import Badge, Award, Issuer
 from slack_badges_bot.services.badge import BadgeService
-from slack_badges_bot.services.award import AwardService
-from slack_badges_bot.services.issuer import IssuerService
 from slack_badges_bot.services.config import ConfigService
-from slack_badges_bot.utils.openbadges import OpenBadges
 from errors import *
 from aiohttp_validate import validate
 
@@ -36,15 +27,10 @@ __copyright__ = "Copyright 2019 {0} <{1}>".format(__author__, __contact__)
 class WebService:
 
     def __init__(self, config: ConfigService,
-            badge_service: BadgeService,
-            award_service: AwardService,
-            issuer_service: IssuerService):
+            badge_service: BadgeService):
         self.config = config
         self.badge_service = badge_service
-        self.award_service = award_service
-        self.issuer_service = issuer_service
         self.app = web.Application()
-        self.openbadges = OpenBadges(config)
         self._setup_routes()
 
     @validate(
@@ -134,67 +120,5 @@ class WebService:
                     return BytesIO(await resp.read())
         raise BadgeImageError(f'WebService.urltobytes: couldn\'t dowload badge image from {url}')
 
-    async def badge_handler(self, request):
-        try:
-            badge_id = request.match_info['badge_id']
-            requested_data = request.match_info['requested_data']
-            badge = self.badge_service.retrieve(badge_id)
-            if requested_data == 'image':
-                image_fd = self.badge_service.open_image(badge)
-                content_type = mimetypes.guess_type(f'file.{badge.image.suffix}')[0]
-                response = web.Response(body=image_fd.read(), content_type=content_type)
-            elif requested_data == 'json':
-                badge_class = self.openbadges.badge_class(badge)
-                response = web.json_response(badge_class)
-            elif requested_data == 'criteria':
-                response = web.json_response({'criteria': badge.criteria})
-            else:
-                response = web.HTTPBadRequest()
-        except:
-            traceback.print_exc(file=sys.stdout)
-            response = web.HTTPInternalServerError()
-        return response
-
-    async def issuer_handler(self, request):
-# Este método devuelve el JSON con la info del issuer
-        try:
-            issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
-            issuer_organization = self.openbadges.issuer_organization(issuer)
-            logging.debug(issuer_organization)
-            response = web.json_response(issuer_organization)
-        except:
-            traceback.print_exc(file=sys.stdout)
-            response = web.HTTPInternalServerError()
-        return response
-
-    async def award_handler(self, request: web.Request):
-        try:
-            award_id = request.match_info['award_id']
-            requested_data = request.match_info['requested_data']
-            award = self.award_service.retrieve(award_id)
-            logging.debug(award)
-            if requested_data == 'json':
-                badge_assertion = self.openbadges.badge_assertion(award)
-                response = web.json_response(badge_assertion)
-            elif requested_data == 'image':
-                image_fd = self.award_service.open_image(award)
-                content_type = mimetypes.guess_type(f'file.{award.image.suffix}')[0]
-                response = web.Response(body=image_fd.read(), content_type=content_type)
-            else:
-                response = web.HTTPBadRequest()
-        except:
-            traceback.print_exc(file=sys.stdout)
-            response = web.HTTPInternalServerError()
-        return response
-
-    async def revocation_handler(self, request: web.Request):
-        issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
-        return web.json_response(issuer.revocationList)
-
     def _setup_routes(self):
         self.app.router.add_post('/badges/create', self.create_badge_handler)
-        self.app.router.add_get('/badges/{badge_id}/{requested_data}', self.badge_handler)
-        self.app.router.add_get('/issuer', self.issuer_handler)
-        self.app.router.add_get('/awards/{award_id}/{requested_data}', self.award_handler)
-        self.app.router.add_get('/revocation', self.revocation_handler)
-        #TODO: self.app.router.add_get('/{entity}/{id}/{requested_data}', self.entity_handler)

--- a/slack_badges_bot/adapters/openbadgesapi.py
+++ b/slack_badges_bot/adapters/openbadgesapi.py
@@ -1,0 +1,91 @@
+import logging
+import json
+import traceback
+import sys
+import mimetypes
+from aiohttp import web
+
+from slack_badges_bot.services.badge import BadgeService
+from slack_badges_bot.services.award import AwardService
+from slack_badges_bot.services.issuer import IssuerService
+from slack_badges_bot.services.config import ConfigService
+from slack_badges_bot.utils.openbadges import OpenBadges
+
+class OpenBadgesWebService:
+    def __init__(self, config: ConfigService,
+            badge_service: BadgeService,
+            award_service: AwardService,
+            issuer_service: IssuerService):
+        self.config = config
+        self.badge_service = badge_service
+        self.award_service = award_service
+        self.issuer_service = issuer_service
+        self.app = web.Application()
+        self.openbadges = OpenBadges(config)
+        self._setup_routes()
+        logging.debug('Started OPENBADGESAWARENLASKDFJ')
+
+    async def badge_handler(self, request):
+        try:
+            logging.debug('LLEGA REQUESST')
+            badge_id = request.match_info['badge_id']
+            requested_data = request.match_info['requested_data']
+            badge = self.badge_service.retrieve(badge_id)
+            if requested_data == 'image':
+                image_fd = self.badge_service.open_image(badge)
+                content_type = mimetypes.guess_type(f'file.{badge.image.suffix}')[0]
+                response = web.Response(body=image_fd.read(), content_type=content_type)
+            elif requested_data == 'json':
+                badge_class = self.openbadges.badge_class(badge)
+                response = web.json_response(badge_class)
+            elif requested_data == 'criteria':
+                response = web.json_response({'criteria': badge.criteria})
+            else:
+                response = web.HTTPBadRequest()
+        except:
+            traceback.print_exc(file=sys.stdout)
+            response = web.HTTPInternalServerError()
+        return response
+
+    async def award_handler(self, request: web.Request):
+        try:
+            award_id = request.match_info['award_id']
+            requested_data = request.match_info['requested_data']
+            award = self.award_service.retrieve(award_id)
+            logging.debug(award)
+            if requested_data == 'json':
+                badge_assertion = self.openbadges.badge_assertion(award)
+                response = web.json_response(badge_assertion)
+            elif requested_data == 'image':
+                image_fd = self.award_service.open_image(award)
+                content_type = mimetypes.guess_type(f'file.{award.image.suffix}')[0]
+                response = web.Response(body=image_fd.read(), content_type=content_type)
+            else:
+                response = web.HTTPBadRequest()
+        except:
+            traceback.print_exc(file=sys.stdout)
+            response = web.HTTPInternalServerError()
+        return response
+
+    async def issuer_handler(self, request):
+# Este método devuelve el JSON con la info del issuer
+        try:
+            issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
+            issuer_organization = self.openbadges.issuer_organization(issuer)
+            logging.debug(issuer_organization)
+            response = web.json_response(issuer_organization)
+        except:
+            traceback.print_exc(file=sys.stdout)
+            response = web.HTTPInternalServerError()
+        return response
+
+    async def revocation_handler(self, request: web.Request):
+        issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
+        return web.json_response(issuer.revocationList)
+
+    def _setup_routes(self):
+        self.app.router.add_get('/badges/{badge_id}/{requested_data}', self.badge_handler)
+        self.app.router.add_get('/issuer', self.issuer_handler)
+        self.app.router.add_get('/awards/{award_id}/{requested_data}', self.award_handler)
+        self.app.router.add_get('/revocation', self.revocation_handler)
+

--- a/slack_badges_bot/adapters/openbadgesapi.py
+++ b/slack_badges_bot/adapters/openbadgesapi.py
@@ -23,11 +23,9 @@ class OpenBadgesWebService:
         self.app = web.Application()
         self.openbadges = OpenBadges(config)
         self._setup_routes()
-        logging.debug('Started OPENBADGESAWARENLASKDFJ')
 
     async def badge_handler(self, request):
         try:
-            logging.debug('LLEGA REQUESST')
             badge_id = request.match_info['badge_id']
             requested_data = request.match_info['requested_data']
             badge = self.badge_service.retrieve(badge_id)
@@ -52,7 +50,6 @@ class OpenBadgesWebService:
             award_id = request.match_info['award_id']
             requested_data = request.match_info['requested_data']
             award = self.award_service.retrieve(award_id)
-            logging.debug(award)
             if requested_data == 'json':
                 badge_assertion = self.openbadges.badge_assertion(award)
                 response = web.json_response(badge_assertion)
@@ -72,7 +69,6 @@ class OpenBadgesWebService:
         try:
             issuer = self.issuer_service.retrieve(self.config['ISSUER_ID'])
             issuer_organization = self.openbadges.issuer_organization(issuer)
-            logging.debug(issuer_organization)
             response = web.json_response(issuer_organization)
         except:
             traceback.print_exc(file=sys.stdout)

--- a/slack_badges_bot/app.py
+++ b/slack_badges_bot/app.py
@@ -70,14 +70,18 @@ def init_app(argv):
     app = web.Application()
     app.add_subapp('/api', adapters.api.WebService(
         config=config,
-        badge_service=container.resolve(services.badge.BadgeService),
-        award_service=container.resolve(services.award.AwardService),
-        issuer_service=container.resolve(services.issuer.IssuerService)
+        badge_service=container.resolve(services.badge.BadgeService)
     ).app)
     app.add_subapp('/slack', adapters.slack.SlackApplication(
         config=config,
         badge_service=container.resolve(services.badge.BadgeService),
         award_service=container.resolve(services.award.AwardService)
+    ).app)
+    app.add_subapp('/openbadges', adapters.openbadgesapi.OpenBadgesWebService(
+        config=config,
+        badge_service=container.resolve(services.badge.BadgeService),
+        award_service=container.resolve(services.award.AwardService),
+        issuer_service=container.resolve(services.issuer.IssuerService)
     ).app)
     return app
 

--- a/slack_badges_bot/entities/entities.py
+++ b/slack_badges_bot/entities/entities.py
@@ -74,6 +74,7 @@ class Issuer:
     name: str
     url: str
     description: str
+    revocationList: dict
 
 
 if __name__ == '__main__': # Probando

--- a/slack_badges_bot/services/__init__.py
+++ b/slack_badges_bot/services/__init__.py
@@ -1,1 +1,1 @@
-#from . import badge, config, repositories, award, person, issuer
+from . import badge, config, repositories, award, person, issuer

--- a/slack_badges_bot/services/award.py
+++ b/slack_badges_bot/services/award.py
@@ -23,7 +23,7 @@ class AwardService(EntityService):
         self.badge_service = badge_service
         self.openbadges = OpenBadges(config)
 
-    def create_award(self, slack_name: str, slack_id: str,
+    def create_award(self, *, slack_name: str, slack_id: str,
                         email: str, badge_name: str):
         """
         Crea una asociación medalla-persona con la imagen de la medalla [badge_name]

--- a/slack_badges_bot/services/issuer.py
+++ b/slack_badges_bot/services/issuer.py
@@ -5,3 +5,4 @@ from slack_badges_bot.entities import Issuer
 class IssuerService(EntityService):
     def __init__(self, entity_repository_factory: EntityRepositoryFactory):
         self.repository = entity_repository_factory(Issuer)
+

--- a/slack_badges_bot/services/person.py
+++ b/slack_badges_bot/services/person.py
@@ -17,7 +17,7 @@ class PersonService(EntityService):
                 return person
         return None
 
-    def create_person(self, slack_name: str, slack_id: str, email: str):
+    def create_person(self, *, slack_name: str, slack_id: str, email: str):
         if self.person_byemail(email):
             raise ValueError(f'{email} ya existe!')
         person = Person(id=EntityID.generate_unique_id(),

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -12,7 +12,7 @@ __copyright__ = "Copyright 2019 {0} <{1}>".format(__author__, __contact__)
 
 class DefaultConfig:
     DEBUG = True
-    API_URL = 'http://vituin-chat.iaas.ull.es/api'
+    API_URL = 'http://vituin-chat.iaas.ull.es/openbadges'
     BADGES_URL = f'{API_URL}/badges'
     AWARDS_URL = f'{API_URL}/awards'
     BADGES_JSON_URL = f'{BADGES_URL}' + '/{}/json' # se usa .format para insertar el id

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -22,6 +22,7 @@ class DefaultConfig:
     AWARDS_IMAGE_URL = f'{AWARDS_URL}' + '/{}/image' # se usa .format para insertar el id
     ISSUER_URL = f'{API_URL}/issuer'
     ISSUER_ID = 'issuer' # nombre del json en data/issuer/
+    REVOCATION_URL = f'{API_URL}/revocation'
     DATA_PATH = '../data'
     BADGES_PATH = '../data/badges'
     BADGE_NAME_MIN_LENGTH = 5

--- a/slack_badges_bot/utils/openbadges.py
+++ b/slack_badges_bot/utils/openbadges.py
@@ -38,7 +38,8 @@ class OpenBadges:
         return {
                 "name": issuer.name,
                 "url": issuer.url,
-                "description": issuer.description
+                "description": issuer.description,
+                "revocationList": self.config['REVOCATION_URL']
                 }
 
     def badge_class(self, badge: Badge):


### PR DESCRIPTION
Con esto quedan separadas, simplemente he movido los métodos de openbadges a la clase nueva y cambiado /api por /openbadges. 
Ahora, qué métodos hay que escribir en la API de la línea de comandos?
Y respecto a lo del Issuer, de qué manera guardo la información (nombre, descripción) sin que sea una entidad/servicio?