### PR TITLE
Seguridad en la API de administración

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+config.ini
+secrets
 data/
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Pipfile
+++ b/Pipfile
@@ -10,12 +10,13 @@ aiohttp = "*"
 punq = "*"
 pillow = "*"
 #aiohttp-validate = {editable = true,git = "https://github.com/alu0100832211/aiohttp_validate"}
-badge-cli = {path = "./badge-cli",editable = true}
+badge-cli = {editable = true,path = "./badge-cli"}
 aiohttp-validate = "*"
 slackclient = "*"
-openbadges-bakery = {editable = true,git = "https://github.com/concentricsky/openbadges-bakery"}
+openbadges-bakery = {git = "https://github.com/concentricsky/openbadges-bakery",editable = true}
 cachetools = "*"
 asyncache = "*"
+aiohttp-basicauth-middleware = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ openbadges-bakery = {git = "https://github.com/concentricsky/openbadges-bakery",
 cachetools = "*"
 asyncache = "*"
 aiohttp-basicauth-middleware = "*"
+bcrypt = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b93bea35bf1821a40b5fc47d16166c3042ae0c438fee2b8cb1c30d628d27d9d8"
+            "sha256": "e7aa707c5a6d8fc9c40a9ee41481462c4cd61d3716c8352d7fd3d8e3bacaee5f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -43,6 +43,13 @@
             ],
             "index": "pypi",
             "version": "==3.5.4"
+        },
+        "aiohttp-basicauth-middleware": {
+            "hashes": [
+                "sha256:fb4ff3b5733ab4475dc21ecb30636542ed74c12e9eb711ac77b61795f25eb104"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
         },
         "aiohttp-validate": {
             "hashes": [
@@ -104,6 +111,12 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "http-basic-auth": {
+            "hashes": [
+                "sha256:ed81a9869dee608478e6477f6f3485b3b04e5378a8685a9b9170f0a7a9e90d96"
+            ],
+            "version": "==1.2.0"
         },
         "idna": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e7aa707c5a6d8fc9c40a9ee41481462c4cd61d3716c8352d7fd3d8e3bacaee5f"
+            "sha256": "565751c10f7d0668be5fa339d8cc2dfa6f8011729698f19b8d312791cc17f86c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -83,6 +83,28 @@
             "editable": true,
             "path": "./badge-cli"
         },
+        "bcrypt": {
+            "hashes": [
+                "sha256:0258f143f3de96b7c14f762c770f5fc56ccd72f8a1857a451c1cd9a655d9ac89",
+                "sha256:0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42",
+                "sha256:19a4b72a6ae5bb467fea018b825f0a7d917789bcfe893e53f15c92805d187294",
+                "sha256:5432dd7b34107ae8ed6c10a71b4397f1c853bd39a4d6ffa7e35f40584cffd161",
+                "sha256:69361315039878c0680be456640f8705d76cb4a3a3fe1e057e0f261b74be4b31",
+                "sha256:6fe49a60b25b584e2f4ef175b29d3a83ba63b3a4df1b4c0605b826668d1b6be5",
+                "sha256:74a015102e877d0ccd02cdeaa18b32aa7273746914a6c5d0456dd442cb65b99c",
+                "sha256:763669a367869786bb4c8fcf731f4175775a5b43f070f50f46f0b59da45375d0",
+                "sha256:8b10acde4e1919d6015e1df86d4c217d3b5b01bb7744c36113ea43d529e1c3de",
+                "sha256:9fe92406c857409b70a38729dbdf6578caf9228de0aef5bc44f859ffe971a39e",
+                "sha256:a190f2a5dbbdbff4b74e3103cef44344bc30e61255beb27310e2aec407766052",
+                "sha256:a595c12c618119255c90deb4b046e1ca3bcfad64667c43d1166f2b04bc72db09",
+                "sha256:c9457fa5c121e94a58d6505cadca8bed1c64444b83b3204928a866ca2e599105",
+                "sha256:cb93f6b2ab0f6853550b74e051d297c27a638719753eb9ff66d1e4072be67133",
+                "sha256:d7bdc26475679dd073ba0ed2766445bb5b20ca4793ca0db32b399dccc6bc84b7",
+                "sha256:ff032765bb8716d9387fd5376d987a937254b0619eff0972779515b5c98820bc"
+            ],
+            "index": "pypi",
+            "version": "==3.1.7"
+        },
         "cachetools": {
             "hashes": [
                 "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae",
@@ -97,6 +119,39 @@
                 "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
             "version": "==2019.6.16"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
+                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
+                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
+                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
+                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
+                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
+                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
+                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
+                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
+                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
+                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
+                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
+                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
+                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
+                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
+                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
+                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
+                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
+                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
+                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
+                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
+                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
+                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
+                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
+                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
+                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
+                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
+                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+            ],
+            "version": "==1.12.3"
         },
         "chardet": {
             "hashes": [
@@ -209,6 +264,13 @@
             ],
             "index": "pypi",
             "version": "==0.3.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:57c65e6d96300fdeedaa9a0094f1460899bcee62cea616ed6b925b20e354eedd",
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
         },
         "pypng": {
             "hashes": [

--- a/badge-cli/badge_cli/badge_cli.py
+++ b/badge-cli/badge_cli/badge_cli.py
@@ -1,17 +1,18 @@
 import os
+import configparser
 if not os.path.exists('config.ini'):
     config = configparser.ConfigParser()
     config['client'] = {}
     client = config['client']
     client['user'] = 'admin'
-    client['server']  = 'localhost:5000/api'
+    client['password'] = 'password'
+    client['server']  = 'http://localhost:5000/api'
     with open('config.ini', 'w') as f:
         config.write(f)
 
 import click
 import json
 import badge_cli.slack_badges_bot_client as api_client
-import configparser
 import getpass
 import sys
 
@@ -132,7 +133,7 @@ def config(user, password, server, list_, parameter):
 
     if server:
         server = input("Server: ")
-        config['client'] = {'server': server}
+        config['server'] = server
 
     if user or password or server:
         with open('config.ini', 'w') as f:

--- a/badge-cli/badge_cli/badge_cli.py
+++ b/badge-cli/badge_cli/badge_cli.py
@@ -1,6 +1,12 @@
 import os
 if not os.path.exists('config.ini'):
-    create_defaultconfig()
+    config = configparser.ConfigParser()
+    config['client'] = {}
+    client = config['client']
+    client['user'] = 'admin'
+    client['server']  = 'localhost:5000/api'
+    with open('config.ini', 'w') as f:
+        config.write(f)
 
 import click
 import json
@@ -134,30 +140,3 @@ def config(user, password, server, list_, parameter):
 
     if list_:
         config.write(sys.stdout)
-
-def create_defaultconfig():
-    click.echo("Creando configuracion")
-    config = configparser.ConfigParser()
-    config['client'] = {}
-    client = config['client']
-    client['user'] = 'admin'
-    client['server']  = 'localhost:5000/api'
-    with open('config.ini', 'w') as f:
-        config.write(f)
-
-
-
-"""
-badgecli config --user [USUARIO]
-badgecli config --password [CONSTRASEÑA]
-badgecli config --server [SERVIDOR]
-"""
-"""
-badgecli create oro.json oro.png
-badgecli create oro.json
-badgecli list --persons
-badgecli list --persons person_id
-badgecli list --permissions
-badgecli list --permissions person_id
-badgecli perm --set
-"""

--- a/badge-cli/badge_cli/badge_cli.py
+++ b/badge-cli/badge_cli/badge_cli.py
@@ -7,7 +7,6 @@ import json
 import badge_cli.slack_badges_bot_client as api_client
 import configparser
 import getpass
-import bcrypt
 import sys
 
 from cachetools import cached, TTLCache
@@ -123,7 +122,7 @@ def config(user, password, server, list_, parameter):
 
     if password:
         pw = getpass.getpass()
-        client['password'] = bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        client['password'] = pw
 
     if server:
         server = input("Server: ")

--- a/badge-cli/badge_cli/slack_badges_bot_client/client.py
+++ b/badge-cli/badge_cli/slack_badges_bot_client/client.py
@@ -14,7 +14,7 @@ def create_badge(json_file, image_file):
             image_bytes = image_file.read()
             prefix = 'data:image/{};base64,'.format(str(Image.open(image_file).format).lower())
             openbadge_json['image'] = prefix + base64.encodebytes(image_bytes).decode('utf-8')
-        r=requests.post(config.BADGES_CREATE, json=openbadge_json)
+        r=requests.post(config.BADGES_CREATE, json=openbadge_json, auth=config.AUTH)
         return r.text
     except Exception as error:
         click.echo(error)
@@ -22,19 +22,18 @@ def create_badge(json_file, image_file):
 
 def persons():
     try:
-        response = requests.get(config.PERSONS_LIST)
+        response = requests.get(config.PERSONS_LIST, auth=config.AUTH)
         if response.status_code != 200:
             raise Exception(response.status_code)
         response = response.json()
     except Exception as error:
-        click.echo(error)
+        click.echo(response.text)
         response = None
     return response
 
-
 def permissions(person_id=None):
     try:
-        response = requests.get(config.PERMISSIONS_LIST)
+        response = requests.get(config.PERMISSIONS_LIST, auth=config.AUTH)
         if response.status_code != 200:
             raise Exception(response.status_code)
         response = response.json()
@@ -50,7 +49,7 @@ def update_permissions(person_id, permission_list, action):
                 "permissions": permission_list,
                 "action": action,
                 }
-        response = requests.post(config.PERSONS_PERMISSIONS_UPDATE, json=data)
+        response = requests.post(config.PERSONS_PERMISSIONS_UPDATE, json=data, auth=config.AUTH)
         response = response.json()
     except Exception as error:
         click.echo(error)

--- a/badge-cli/badge_cli/slack_badges_bot_client/config.py
+++ b/badge-cli/badge_cli/slack_badges_bot_client/config.py
@@ -1,4 +1,8 @@
-API_URL = 'http://vituin-chat.iaas.ull.es/api'
+import configparser
+config  = configparser.ConfigParser()
+config.read('config.ini') # Duda: por qué no ../config.ini ?
+API_URL = config['client']['server']
+AUTH = (config['client']['user'], config['client']['password'])
 
 # URLs de funcionalidades
 BADGES_CREATE = API_URL + '/badges/create'

--- a/slack_badges_bot/adapters/api.py
+++ b/slack_badges_bot/adapters/api.py
@@ -9,6 +9,8 @@ import re
 
 from aiohttp import web
 from aiohttp import ClientSession
+from aiohttp_basicauth_middleware import basic_auth_middleware
+
 from pathlib import Path
 from io import BytesIO
 from dataclasses import asdict
@@ -195,3 +197,10 @@ class WebService:
 
         self.app.router.add_get(self.config['ADMIN_PERMISSIONS_LIST'],
                 self.list_permissions_handler)
+        self.app.middlewares.append(
+                basic_auth_middleware(
+                    ('/',),
+                    {self.config['ADMIN_USER']:self.config['ADMIN_PASSWORD']}
+                    )
+                )
+

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -1,9 +1,9 @@
 """Configuración por defecto de la aplicación.
 """
 import os
-import secrets
 
 from pathlib import Path
+from getpass import getpass
 
 
 __author__ = 'Jesús Torres'
@@ -30,8 +30,8 @@ class DefaultConfig:
     ADMIN_PERMISSIONS_UPDATE = '/persons/permissions/update'
     ADMIN_PERMISSIONS_LIST = '/persons/permissions/list'
     ADMIN_PERSONS_LIST = '/persons/list'
-    ADMIN_USER = secrets.admin_user
-    ADMIN_PASSWORD = secrets.admin_password
+    ADMIN_USER = 'admin'
+    ADMIN_PASSWORD = getpass('Set app admin password: ')
 
 # Rutas de persistencia
     DATA_PATH = '../data'

--- a/slack_badges_bot/settings.py
+++ b/slack_badges_bot/settings.py
@@ -1,6 +1,7 @@
 """Configuración por defecto de la aplicación.
 """
 import os
+import secrets
 
 from pathlib import Path
 
@@ -14,7 +15,7 @@ class DefaultConfig:
     DEBUG = True
 
 # API de openbadges
-    API_URL = 'http://vituin-chat.iaas.ull.es/openbadges'
+    API_URL = 'https://vituin-chat.iaas.ull.es/openbadges'
     API_BADGES = '/badges/{badge_id}/{requested_data}'
     API_AWARDS = '/awards/{award_id}/{requested_data}'
     API_ISSUER = '/issuer'
@@ -29,6 +30,8 @@ class DefaultConfig:
     ADMIN_PERMISSIONS_UPDATE = '/persons/permissions/update'
     ADMIN_PERMISSIONS_LIST = '/persons/permissions/list'
     ADMIN_PERSONS_LIST = '/persons/list'
+    ADMIN_USER = secrets.admin_user
+    ADMIN_PASSWORD = secrets.admin_password
 
 # Rutas de persistencia
     DATA_PATH = '../data'


### PR DESCRIPTION
Fix #20 

Ahora al ejecutar el servidor pregunta por una contraseña del administrador de la aplicación

Con la ayuda de https://github.com/bugov/aiohttp-basicauth-middleware todas las solicitudes que van por la url https://vituin-chat.iaas.ull.es/api les pide autenticación:

```code

 $  curl -i https://vituin-chat.iaas.ull.es/api/persons/list    

HTTP/1.1 401 Unauthorized
Server: nginx/1.17.1
Date: Thu, 22 Aug 2019 19:03:07 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 17
Connection: keep-alive
WWW-Authenticate: Basic

401: Unauthorized%
```
```code
$ curl -i --user admin:password https://vituin-chat.iaas.ull.es/api/persons/list


HTTP/1.1 200 OK
Server: nginx/1.17.1
Date: Thu, 22 Aug 2019 19:03:03 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 498
Connection: keep-alive

[{"id": "4df82eb378ea4e07af20de9096f754f0", "email": "jmtorres@ull.edu.es", "slack_id": "UJ7HEC01M", "slack_name": "jmtorres", "real_name": "Jes\u00fas Torres", "permissions": ["badges:list", "awards:list:self"]}, {"id": "a7bf98b8b4424d1d816a7c29cf9c627f", "email": "alu0100832211@ull.edu.es", "slack_id": "UHYNH5UL9", "slack_name": "alu0100832211", "real_name": "Mart\u00edn", "permissions": ["awards:create:self", "awards:create:others", "badges:list", "awards:list:self", "awards:list:others"]}]%      
``` 


Fix #19  Ahora hay un subcomando config que permite configurar tres parametros: usuario, contraseña y servidor
```shell
$ badgecli config --help
Usage: badgecli config [OPTIONS] [PARAMETER]

  Configurar parámetros de la línea de comandos

Options:
  -u, --user      Nombre de usuario
  -p, --password  Contraseña del administrador
  -s, --server    Ruta de administracion del servidor
  -l, --list      mostrar toda la config
  --help          Show this message and exit.
``` 
